### PR TITLE
Port to coral-v2

### DIFF
--- a/comd-mp4/src-omp/Makefile
+++ b/comd-mp4/src-omp/Makefile
@@ -10,8 +10,7 @@ DOUBLE_PRECISION = ON
 # MPI for parallel (ON/OFF)
 DO_MPI = OFF
 
-CLANG=/usr/local/llvm_openmp/bin/clang
-OMPTARGET=nvptx64sm_30-linux-gnu,nvptx64sm_50-linux-gnu
+OMPTARGET=nvptx64-nvidia-cuda
 
 ### Set your desired C compiler and any necessary flags.  Note that CoMD
 ### uses some c99 features.  You can also set flags for optimization and
@@ -20,10 +19,10 @@ OMPTARGET=nvptx64sm_30-linux-gnu,nvptx64sm_50-linux-gnu
 ### (such as -lm for the math library) put them in C_LIB.
 #CC = mpicc
 CC = $(CLANG)
-FLAGS = -O3 -g 
-FLAGS = -O3 -g -fopenmp=libomp -omptargets=$(OMPTARGET) -target x86_64-pc-linux-gnu
+FLAGS = -O3
+FLAGS = -O3 -fopenmp -fopenmp-targets=$(OMPTARGET) -target x86_64-pc-linux-gnu
 
-CFLAGS = -O3 -g -std=c99  
+CFLAGS = -O3 -std=c99
 FLAGS += -D__GPU__ -I$(LIBOMP_LIB)
 OPTFLAGS = 
 INCLUDES = 
@@ -86,7 +85,7 @@ OBJECTS=$(SOURCES:.c=.o)
 DEFAULT: ${CoMD_EXE}
 
 %.o: %.c
-	${CC} ${CFLAGS} -c $< -o $@
+	${CC} ${CFLAGS} ${FLAGS} -c $< -o $@
 
 ljForce.o: ljForce.c
 	${CC} ${CFLAGS} $(FLAGS) -c $< -o $@

--- a/hpgmg-mp4/local.mk
+++ b/hpgmg-mp4/local.mk
@@ -1,1 +1,1 @@
-include $(call incsubdirs,finite-element finite-volume)
+include $(call incsubdirs,finite-volume)

--- a/lulesh-mp4/Makefile
+++ b/lulesh-mp4/Makefile
@@ -41,7 +41,7 @@ mpi = -DUSE_MPI=$(USE_MPI)
 endif
 
 # Tuning flags for Power 8
-CXXFLAGS = -fopenmp=libomp -O3 -omptargets=nvptx64sm_50-linux-gnu $(shared) $(mpi) $(teams) $(threads) $(gpu) -I$(LIBOMP_LIB) -target x86_64-px-linux-gnu
+CXXFLAGS = -fopenmp -O3 -fopenmp-targets=nvptx64-nvidia-cuda $(shared) $(mpi) $(teams) $(threads) $(gpu) -I$(LIBOMP_LIB) -target x86_64-pc-linux-gnu
 
 LDFLAGS = -L$(LIBOMP_LIB) -L$(CUDA)/lib64  -lcuda -lcudart -lelf -lffi -target x86_64-pc-linux-gnu
 
@@ -53,7 +53,7 @@ all: $(LULESH_EXEC)
 
 lulesh2.0: $(OBJECTS2.0)
 	@echo "Linking"
-	$(CXX) -fopenmp=libomp -omptargets=nvptx64sm_50-linux-gnu $(OBJECTS2.0) $(LDFLAGS) -lomp -lomptarget -lstdc++ -lm -o $@
+	$(CXX) -fopenmp=libomp $(CXXFLAGS) $(OBJECTS2.0) $(LDFLAGS) -lomp -lomptarget -lstdc++ -lm -o $@
 
 clean:
 	/bin/rm -f *.o *~ *.tgt* $(OBJECTS) $(LULESH_EXEC)

--- a/snap-mp4/src/Makefile
+++ b/snap-mp4/src/Makefile
@@ -1,15 +1,13 @@
 MP4BUILD = 1
 
-CLANG=/usr/local/llvm_openmp/bin/clang++
-
-OMPTARGET=nvptx64sm_50-linux-gnu
+OMPTARGET=nvptx64-nvidia-cuda
 CPUTARGET=x86_64-pc-linux-gnu
 
 ifdef MP4BUILD 
-CXXFLAGS = -g -O3 -fopenmp=libomp -omptargets=$(OMPTARGET) -I/usr/lib/openmpi/include -I$(LIBOMP_LIB)
-CXXLNKFLAGS = -g -fopenmp=libomp -omptargets=$(OMPTARGET)
-LFLAGS = -target nvptx64sm_50-linux-gnu
-LIBS = -L$(LIBOMP_LIB) -L$(CUDA)/lib64 -lm -lcuda -lcudart -lelf -lffi 
+CXXFLAGS = -O3 -fopenmp -fopenmp-targets=$(OMPTARGET) -I/usr/lib/openmpi/include -I$(LIBOMP_LIB) -target $(CPUTARGET)
+CXXLNKFLAGS = -fopenmp -fopenmp-targets=$(OMPTARGET) -target $(CPUTARGET)
+LFLAGS = -target $(CPUTARGET)
+LIBS = -L$(LIBOMP_LIB) -L$(CUDA)/lib64 -lm -lcuda -lcudart -lelf -lffi -lstdc++
 else
 CXXFLAGS = -g -O3 -I/usr/lib/openmpi/include 
 CXXLNKFLAGS = -g 

--- a/xsbench-mp4/src/Makefile
+++ b/xsbench-mp4/src/Makefile
@@ -36,12 +36,12 @@ obj = $(source:.c=.o)
 LDFLAGS = -lm
 
 ifeq ($(COMPILER),mp4)
-  OMPTARGET=nvptx64sm_50-linux-gnu
+  OMPTARGET=nvptx64-nvidia-cuda
   CPUTARGET=x86_64-pc-linux-gnu
-  CFLAGS = -O3 -g -fopenmp=libomp -omptargets=$(OMPTARGET)
+  CFLAGS = -O3 -fopenmp -fopenmp-targets=$(OMPTARGET) -target $(CPUTARGET)
   CC = $(CLANG)
   CFLAGS += -D__GPU__ -I$(LIBOMP_LIB)
-  LDFLAGS = -fopenmp=libomp -omptargets=$(OMPTARGET) -target x86_64-pc-linux-gnu -L$(LIBOMP_LIB) -L$(CUDA)/lib64 -lcuda -lcudart -lelf -lffi
+  LDFLAGS = -fopenmp -fopenmp-targets=$(OMPTARGET) -target $(CPUTARGET) -L$(LIBOMP_LIB) -L$(CUDA)/lib64 -lcuda -lcudart -lelf -lffi
 endif
 
 # GNU Compiler


### PR DESCRIPTION
Port to use coral-v2 with following main changes:

 (1) Target starting with nvptx64sm_ is no longer valid. Use nvptx64-nvidia-cuda

 (2) -omptargets option is no longer valid. Use -fopenmp-targets instead

 (3) Must provide cpu target to make clang-offload-bundler work

 (4) Fix cpu target typo in lulesh-mp4/Makefile

 (5) Link libstdc++ in snap-mp4/src/Makefile

 (6) finite-element folder does not exist. Remove it from hpgmg-mp4/local.mk