### PR TITLE
Update matmul.c

### DIFF
--- a/matmul-weights/src/matmul.c
+++ b/matmul-weights/src/matmul.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
   fprintf(stderr, "Starting matmul\n");
   // time the data copy separate from gflops
   clock_gettime(CLOCK_REALTIME, &t0);
-  #pragma omp target data map(to: matA, matB) map(from: matC)
+  #pragma omp target data map(to: matA, matB) map(tofrom: matC)
   {
     clock_gettime(CLOCK_REALTIME, &t1);
     // leaving num_threads and teams off, to allow easier env-var control


### PR DESCRIPTION
Issue SWDEV-474904 observing failure in OpenMP Apps in weighted matmul operation

Resolution: We need to map matC is initialized with the value of 0.0 in list move to device data environment to host and then back, hence use map tofrom